### PR TITLE
Add images for Ubuntu 26.04

### DIFF
--- a/.github/workflows/systemd-Ubuntu.resolute-ci.yml
+++ b/.github/workflows/systemd-Ubuntu.resolute-ci.yml
@@ -1,0 +1,60 @@
+---
+name: "Ubuntu.resolute - systemd"
+
+'on':
+  push:
+    branches:
+      - main
+    paths:
+      - "Containerfiles/systemd/Ubuntu/Ubuntu.resolute.Containerfile"
+      - ".github/workflows/systemd-Ubuntu.resolute-ci.yml"
+  schedule:
+    - cron: "10 1 * * 0"
+  workflow_dispatch:
+
+jobs:
+  build_push:
+    name: Build and Push container images to quay.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Calculate Docker image tags # Based on https://gist.github.com/sagikazarmark/0119e1f3dde0d8e755fd0ee5a5ef4cdc
+        id: tags
+        run: |
+          case $GITHUB_REF in
+            refs/tags/*)  VERSION=${GITHUB_REF#refs/tags/};;
+            refs/heads/*) VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g');;
+            refs/pull/*)  VERSION=pr-${{ github.event.number }};;
+            *)            VERSION=sha-${GITHUB_SHA::8};;
+          esac
+          echo version=${VERSION} >> ${GITHUB_OUTPUT}
+          echo commit_hash=${GITHUB_SHA::8} >> ${GITHUB_OUTPUT}
+          echo build_date=$(git show -s --format=%cI) >> ${GITHUB_OUTPUT}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and push image.
+        uses: docker/build-push-action@v6
+        with:
+          context: ./Containerfiles/systemd/Ubuntu
+          file: ./Containerfiles/systemd/Ubuntu/Ubuntu.resolute.Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          labels: |
+            org.opencontainers.image.tite="Ubuntu image with systemd"
+            org.opencontainers.image.description="Ubuntu image with systemd for Ansible testing using Podman and Molecule"
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}/tree/main/Containerfiles/systemd
+            org.opencontainers.image.documentation=${{ github.event.repository.html_url }}/tree/main/Containerfiles/systemd/README.md
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.tags.outputs.version }}
+            org.opencontainers.image.created=${{ steps.tags.outputs.build_date }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          tags: |
+            quay.io/gotmax23/ubuntu-systemd:resolute
+            quay.io/gotmax23/ubuntu-systemd:26.04

--- a/Containerfiles/systemd/README.md
+++ b/Containerfiles/systemd/README.md
@@ -178,7 +178,7 @@ ansible_distribution: Ubuntu
 
 # These aren't actually Ansible variables
 galaxy_platform: Ubuntu
-container_repo: quay.io/gotmax23/debian-systemd
+container_repo: quay.io/gotmax23/ubuntu-systemd
 ```
 
 | Available Tags        | `galaxy_version` | `ansible_distribution_major_verison` | `ansible_distribution_version` | `ansible_distribution_release` |
@@ -186,6 +186,7 @@ container_repo: quay.io/gotmax23/debian-systemd
 | focal,20,20.04        | focal            | "20"                                 | "20.04"                        | "focal"                        |
 | jammy,22.04           | jammy[^1]        | "22"                                 | "22.04"                        | "jammy"                        |
 | noble,24.04           | noble[^1]        | "24"                                 | "24.04"                        | "noble"                        |
+| resolute,26.04        | resolute[^1]     | "26"                                 | "26.04"                        | "resolute"                     |
 
 ## Contributing
 

--- a/Containerfiles/systemd/Ubuntu/Ubuntu.resolute.Containerfile
+++ b/Containerfiles/systemd/Ubuntu/Ubuntu.resolute.Containerfile
@@ -1,0 +1,23 @@
+#
+# Ansible managed
+#
+
+FROM docker.io/library/ubuntu:resolute
+LABEL maintainer="Maxwell G <gotmax23@github>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo "**** Installing packages and updating if necessary ****" \
+    && apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
+        systemd python3 sudo ca-certificates systemd-sysv python3-apt \
+    && echo "**** Cleaning package cache ****" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "**** Masking systemd services ****" \
+    && systemctl mask \
+        systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount getty.target console-getty.service systemd-udev-trigger.service systemd-udevd.service systemd-random-seed.service systemd-machine-id-commit.service
+
+CMD ["/sbin/init"]
+STOPSIGNAL SIGRTMIN+3
+
+# vim: set filetype=dockerfile:

--- a/src/systemd/matrix.yml
+++ b/src/systemd/matrix.yml
@@ -285,3 +285,7 @@ distros:
           extra_CI_image_tags:
             - "24.04"
             - "latest"
+      - baseimage_version: resolute
+        vars:
+          extra_CI_image_tags:
+            - "26.04"


### PR DESCRIPTION
With Ubuntu 26.04 release approaching, we may add a build job for it a bit in advance.

Official Docker image which we are using as a base is already available.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>